### PR TITLE
Added Spotify Embedded Player

### DIFF
--- a/src/components/EmbeddedSpotifyPlayer/EmbeddedSpotifyPlayer.tsx
+++ b/src/components/EmbeddedSpotifyPlayer/EmbeddedSpotifyPlayer.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export const EmbeddedSpotifyPlayer = ({ trackId }: { trackId: string }) => {
+  return (
+    <iframe
+      style={{ borderRadius: "12px", width: "100%", height: "152px" }}
+      src={`https://open.spotify.com/embed/track/${trackId}?utm_source=generator`}
+      frameBorder="0"
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      loading="lazy"
+    ></iframe>
+  );
+};

--- a/src/components/Playlist/PlaylistBuilder.css
+++ b/src/components/Playlist/PlaylistBuilder.css
@@ -18,10 +18,12 @@
 
 .tracks-container {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   flex-wrap: wrap;
-  gap: 2rem;
+  gap: 4rem;
   margin-bottom: 3rem;
+  align-items: center; /* Center items vertically */
+  position: relative; /* For absolute positioning */
 }
 
 .track-card {
@@ -70,6 +72,10 @@
   padding: 1.5rem;
   border-radius: 8px;
   margin-top: 2rem;
+  max-width: 775px;
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .playlist-section h3 {
@@ -77,10 +83,11 @@
   color: #1db954;
 }
 
+/* Make sure the elements inside remain well formatted with the new width */
 .selected-tracks {
-  list-style: none;
   padding: 0;
   margin: 0;
+  list-style-type: none;
 }
 
 .selected-track {
@@ -99,6 +106,7 @@
   height: 50px;
   border-radius: 4px;
   margin-right: 1rem;
+  object-fit: cover;
 }
 
 .selected-track div {
@@ -111,6 +119,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: left;
 }
 
 .selected-track span {
@@ -119,6 +128,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: left;
 }
 
 .loading {
@@ -207,4 +217,55 @@
   background-color: #222;
   color: #999;
   font-style: italic;
+}
+
+.embedded-player {
+  margin-top: 15px;
+  width: 100%;
+}
+
+.vs-badge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1db954 0%, #169c46 100%);
+  box-shadow: 0 4px 12px rgba(29, 185, 84, 0.4);
+  z-index: 2;
+  margin: 0 1rem;
+  animation: pulse 2s infinite;
+}
+
+.vs-text {
+  color: white;
+  font-weight: bold;
+  font-size: 1.5rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  letter-spacing: 1px;
+}
+
+/* Add a pulse animation */
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Alternative layouts for different screen sizes */
+@media (max-width: 800px) {
+  .tracks-container {
+    flex-direction: column;
+  }
+
+  .vs-badge {
+    margin: 1rem 0; /* Add vertical space when stacked */
+  }
 }

--- a/src/components/Playlist/PlaylistBuilder.tsx
+++ b/src/components/Playlist/PlaylistBuilder.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import SpotifyService from "../../services/spotify.service";
 import { Track } from "../../types/spotify.types";
 import "./PlaylistBuilder.css";
+import { EmbeddedSpotifyPlayer } from "../EmbeddedSpotifyPlayer/EmbeddedSpotifyPlayer";
+import VolumeWarning from "../VolumeWarning/VolumeWarning";
 
 const PlaylistBuilder: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -125,55 +127,69 @@ const PlaylistBuilder: React.FC = () => {
   return (
     <div className="playlist-builder">
       <h1>TrackDuel</h1>
-
+      <VolumeWarning />
       <div className="track-comparison">
         <h2>Choose your favorite track</h2>
         <div className="tracks-container">
-          {tracks.map((track) => (
-            <div
-              key={track.id}
-              className="track-card"
-              onClick={() => handleTrackSelect(track)}
-            >
-              <img
-                src={track.album?.images?.[0]?.url || "/placeholder-album.png"}
-                alt={track.album?.name || "Album"}
-                className="album-cover"
-              />
-              <div className="track-info">
-                <h3>{track.name}</h3>
-                <p>
-                  {track.artists?.map((artist) => artist.name).join(", ") ||
-                    "Unknown Artist"}
-                </p>
-                <div className="track-genres">
-                  {(track.genres || []).length > 0 ? (
-                    (track.genres || []).slice(0, 4).map((genre, index) => (
-                      <span key={index} className="genre-tag">
-                        {genre}
+          {tracks.map((track, index) => (
+            <React.Fragment key={track.id}>
+              <div
+                className="track-card"
+                onClick={() => handleTrackSelect(track)}
+              >
+                {/* Track card content */}
+                <img
+                  src={
+                    track.album?.images?.[0]?.url || "/placeholder-album.png"
+                  }
+                  alt={track.album?.name || "Album"}
+                  className="album-cover"
+                />
+                <div className="track-info">
+                  <h3>{track.name}</h3>
+                  <p>
+                    {track.artists?.map((artist) => artist.name).join(", ") ||
+                      "Unknown Artist"}
+                  </p>
+                  <div className="track-genres">
+                    {(track.genres || []).length > 0 ? (
+                      (track.genres || []).slice(0, 3).map((genre, index) => (
+                        <span key={index} className="genre-tag">
+                          {genre}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="genre-tag genre-tag--muted">
+                        Uncategorized
                       </span>
-                    ))
-                  ) : (
-                    <span className="genre-tag genre-tag--muted">
-                      Uncategorized
+                    )}
+                  </div>
+                  <div className="track-meta">
+                    <span className="release-year">
+                      {track.album.release_date?.substring(0, 4)}
                     </span>
-                  )}
-                </div>
-                <div className="track-meta">
-                  <span className="release-year">
-                    {track.album.release_date?.substring(0, 4)}
-                  </span>
-                  <span
-                    className="popularity"
-                    title={`Popularity: ${track.popularity}/100`}
-                  >
-                    {Array(Math.max(1, Math.ceil(track.popularity / 20)))
-                      .fill("★")
-                      .join("")}
-                  </span>
+                    <span
+                      className="popularity"
+                      title={`Popularity: ${track.popularity}/100`}
+                    >
+                      {Array(Math.max(1, Math.ceil(track.popularity / 20)))
+                        .fill("★")
+                        .join("")}
+                    </span>
+                  </div>
+                  <div className="embedded-player">
+                    <EmbeddedSpotifyPlayer trackId={track.id} />
+                  </div>
                 </div>
               </div>
-            </div>
+
+              {/* Add VS element between tracks */}
+              {index === 0 && tracks.length > 1 && (
+                <div className="vs-badge">
+                  <div className="vs-text">VS</div>
+                </div>
+              )}
+            </React.Fragment>
           ))}
         </div>
         <div className="playlist-section">

--- a/src/components/VolumeWarning/VolumeWarning.css
+++ b/src/components/VolumeWarning/VolumeWarning.css
@@ -1,0 +1,66 @@
+.volume-warning {
+  padding: 15px;
+  margin: 15px auto;
+  background-color: #282828;
+  border-left: 4px solid #ffcc00;
+  border-radius: 8px;
+  text-align: center;
+  max-width: 730px;
+}
+
+.warning-content {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  align-items: center;
+}
+
+.warning-message {
+  color: #ffcc00;
+  margin: 0;
+}
+
+.warning-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.warning-button {
+  padding: 8px 16px;
+  border-radius: 30px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+  text-decoration: none;
+  display: inline-block;
+  text-align: center;
+}
+
+.dismiss-button {
+  background-color: #1db954;
+  color: white;
+}
+
+.dismiss-button:hover {
+  background-color: #1ed760;
+}
+
+.settings-button {
+  background-color: transparent;
+  border: 1px solid #1db954;
+  color: #1db954;
+}
+
+.settings-button:hover {
+  background-color: rgba(29, 185, 84, 0.1);
+}
+
+@media (max-width: 600px) {
+  .warning-actions {
+    flex-direction: column;
+  }
+}

--- a/src/components/VolumeWarning/VolumeWarning.tsx
+++ b/src/components/VolumeWarning/VolumeWarning.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from "react";
+import "./VolumeWarning.css";
+
+const VolumeWarning = () => {
+  const [isDismissed, setIsDismissed] = useState<boolean>(true);
+
+  useEffect(() => {
+    const hasSeenWarning = localStorage.getItem("volumeWarningDismissed");
+    setIsDismissed(hasSeenWarning === "true");
+  }, []);
+
+  const handleDismiss = () => {
+    setIsDismissed(true);
+    localStorage.setItem("volumeWarningDismissed", "true");
+  };
+
+  if (isDismissed) return null;
+
+  return (
+    <div className="volume-warning">
+      <div className="warning-content">
+        <p className="warning-message">
+          ⚠️ The embedded Spotify player starts at full volume! Please lower
+          your system volume before playing.
+        </p>
+        <div className="warning-actions">
+          <button
+            className="warning-button dismiss-button"
+            onClick={handleDismiss}
+          >
+            Got it, thanks!
+          </button>
+          {navigator.platform.includes("Win") && (
+            <a
+              href="ms-settings:sound"
+              className="warning-button settings-button"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open Sound Settings
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VolumeWarning;


### PR DESCRIPTION
Closes #8 

This pull request implements embedded track players within the TrackDuel interface, allowing users to preview songs before making their selection. We've addressed concerns about volume control and user experience with several thoughtful enhancements.

**Spotify Embedded Player Integration**
- Created a new `EmbeddedSpotifyPlayer` component that wraps Spotify's iframe player

**Volume Warning System**
- Added a `VolumeWarning` component that alerts users about audio volume before playback
- Implemented persistent dismissal using localStorage so users only see the warning once

**Visual Design Enhancements**
- Added a stylish animated "VS" badge between competing tracks to reinforce the duel concept
- Improved track card spacing for better visual balance, especially on vertical displays
- Fixed text overflow issues in track information display
