### PR TITLE
Create Modal Confirmation for Playlist Clearing

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.css
+++ b/src/components/ConfirmationModal/ConfirmationModal.css
@@ -1,0 +1,165 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.modal-content {
+  background-color: #282828;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 500px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  animation: slideIn 0.3s ease-out;
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #333;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal-header-danger {
+  border-bottom-color: rgba(220, 53, 69, 0.5);
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: white;
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #999;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.modal-close-btn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.modal-body {
+  padding: 20px;
+  font-size: 0.95rem;
+  color: #ddd;
+  line-height: 1.5;
+}
+
+.modal-body p {
+  margin: 0;
+}
+
+.modal-footer {
+  padding: 16px 20px;
+  border-top: 1px solid #333;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.modal-btn {
+  padding: 8px 16px;
+  border-radius: 30px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+  outline: none;
+}
+
+.cancel-btn {
+  background-color: transparent;
+  color: #999;
+  border: 1px solid #555;
+}
+
+.cancel-btn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.confirm-btn {
+  background-color: #1db954;
+  color: white;
+}
+
+.confirm-btn:hover {
+  background-color: #1ed760;
+}
+
+.confirm-danger-btn {
+  background-color: #dc3545;
+  color: white;
+}
+
+.confirm-danger-btn:hover {
+  background-color: #e04050;
+}
+
+/* Accessibility focus styles */
+.modal-btn:focus,
+.modal-close-btn:focus {
+  outline: 2px solid #1db954;
+  outline-offset: 2px;
+}
+
+/* Mobile responsive adjustments */
+@media (max-width: 576px) {
+  .modal-content {
+    width: 95%;
+  }
+
+  .modal-footer {
+    flex-direction: column-reverse;
+  }
+
+  .modal-btn {
+    width: 100%;
+    padding: 12px;
+  }
+}

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from "react";
+import ReactDOM from "react-dom";
+import "./ConfirmationModal.css";
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmText: string;
+  cancelText: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDanger?: boolean;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+  isDanger = false,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Handle escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden"; // Prevent scrolling behind modal
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = ""; // Re-enable scrolling when modal closes
+    };
+  }, [isOpen, onCancel]);
+
+  // Handle focus trapping
+  useEffect(() => {
+    const focusableElements = modalRef.current?.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (isOpen && focusableElements && focusableElements.length > 0) {
+      const firstElement = focusableElements[0] as HTMLElement;
+      firstElement.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <div className="modal-overlay" onClick={onCancel}>
+      <div
+        className="modal-content"
+        onClick={(e) => e.stopPropagation()}
+        ref={modalRef}
+      >
+        <div
+          className={`modal-header ${isDanger ? "modal-header-danger" : ""}`}
+        >
+          <h3>{title}</h3>
+          <button className="modal-close-btn" onClick={onCancel}>
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
+          <p>{message}</p>
+        </div>
+        <div className="modal-footer">
+          <button className="modal-btn cancel-btn" onClick={onCancel}>
+            {cancelText}
+          </button>
+          <button
+            className={`modal-btn ${
+              isDanger ? "confirm-danger-btn" : "confirm-btn"
+            }`}
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ConfirmationModal;

--- a/src/components/Playlist/PlaylistBuilder.tsx
+++ b/src/components/Playlist/PlaylistBuilder.tsx
@@ -11,6 +11,7 @@ import {
   clearPlaylist,
 } from "../../store/playlistSlice";
 import { store } from "../../store/store";
+import ConfirmationModal from "../ConfirmationModal/ConfirmationModal";
 
 const PlaylistBuilder: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -21,6 +22,7 @@ const PlaylistBuilder: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   // const [selectedTracks, setSelectedTracks] = useState<Track[]>([]);
   const [seenTrackIds, setSeenTrackIds] = useState<Set<string>>(new Set());
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState<boolean>(false);
 
   const playlistId = "69fEt9DN5r4JQATi52sRtq";
 
@@ -159,12 +161,20 @@ const PlaylistBuilder: React.FC = () => {
   //   });
   // }, [selectedTracks]);
 
-  // Add a function to clear playlist
+  // Updated clear playlist function to open modal
   const handleClearPlaylist = () => {
-    // Use window.confirm explicitly to avoid ESLint error
-    if (window.confirm("Are you sure you want to clear your playlist?")) {
-      dispatch(clearPlaylist());
-    }
+    setIsConfirmModalOpen(true);
+  };
+
+  // New function to handle confirmation
+  const handleConfirmClear = () => {
+    dispatch(clearPlaylist());
+    setIsConfirmModalOpen(false);
+  };
+
+  // New function to handle cancel
+  const handleCancelClear = () => {
+    setIsConfirmModalOpen(false);
   };
 
   if (isLoading) {
@@ -263,6 +273,16 @@ const PlaylistBuilder: React.FC = () => {
                 Clear All
               </button>
             )}
+            <ConfirmationModal
+              isOpen={isConfirmModalOpen}
+              title="Clear Playlist"
+              message="Are you sure you want to clear all tracks from your playlist? This action cannot be undone."
+              confirmText="Clear Playlist"
+              cancelText="Cancel"
+              onConfirm={handleConfirmClear}
+              onCancel={handleCancelClear}
+              isDanger={true}
+            />
           </div>
           {selectedTracks.length > 0 ? (
             <ul className="selected-tracks">


### PR DESCRIPTION
Closes #18 

This pull request introduces a new `ConfirmationModal` component and integrates it with the `PlaylistBuilder` to handle playlist clearing operations. The most important changes include the creation of the modal component, its styling, and the integration with the existing playlist functionality.

### New Component Creation:

* [`src/components/ConfirmationModal/ConfirmationModal.tsx`](diffhunk://#diff-87c501c5c76151a253b362e0b6e07c88390ef9ee5857aff63823e5bf5a1a4557R1-R98): Created the `ConfirmationModal` component with properties to handle open state, title, message, confirm and cancel actions, and a danger flag for styling.

### Styling:

* [`src/components/ConfirmationModal/ConfirmationModal.css`](diffhunk://#diff-c0b43292ed3051140c33b4a9d7b5919787a50ec89c87a682fb4b7f2a1dbdc9c1R1-R165): Added CSS styles for the `ConfirmationModal` component, including animations, layout, and responsive adjustments.

### Integration with PlaylistBuilder:

* `src/components/Playlist/PlaylistBuilder.tsx`: 
  - Imported the `ConfirmationModal` component.
  - Added state management for the modal's open state.
  - Updated the `handleClearPlaylist` function to open the modal instead of using `window.confirm`.
  - Added the `ConfirmationModal` component to the JSX, passing necessary props and handlers.