### PR TITLE
Added Track Skipping Functionality to TrackDuel

### DIFF
--- a/src/components/Playlist/PlaylistBuilder.css
+++ b/src/components/Playlist/PlaylistBuilder.css
@@ -346,3 +346,66 @@
 .save-playlist-btn:hover {
   background-color: #1ed760;
 }
+
+/* Skip button styles */
+.skip-button-container {
+  display: flex;
+  justify-content: center;
+  margin: 1.5rem 0;
+}
+
+.skip-button {
+  background-color: #333;
+  color: #fff;
+  border: 2px solid #1db954;
+  border-radius: 30px;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.skip-button:hover {
+  background-color: #444;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.skip-button:active {
+  transform: translateY(0);
+}
+
+.skip-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.skip-icon {
+  font-size: 1.2rem;
+  display: inline-block;
+  transition: transform 0.3s ease;
+}
+
+.skip-button:hover .skip-icon {
+  transform: rotate(180deg);
+}
+
+/* Add a loading state animation */
+.skip-button.loading .skip-icon {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Playlist/PlaylistBuilder.tsx
+++ b/src/components/Playlist/PlaylistBuilder.tsx
@@ -177,6 +177,12 @@ const PlaylistBuilder: React.FC = () => {
     setIsConfirmModalOpen(false);
   };
 
+  // Skip tracks function
+  const handleSkipTracks = async () => {
+    console.log("Skipping current tracks...");
+    await fetchTracks();
+  };
+
   if (isLoading) {
     return <div className="loading">Loading tracks...</div>;
   }
@@ -260,6 +266,17 @@ const PlaylistBuilder: React.FC = () => {
               )}
             </React.Fragment>
           ))}
+        </div>
+        <div className="skip-button-container">
+          <button
+            className="skip-button"
+            onClick={handleSkipTracks}
+            disabled={isLoading}
+            title="Skip both tracks and get new ones"
+          >
+            <span className="skip-icon">↻</span>
+            Skip both tracks
+          </button>
         </div>
         <div className="playlist-section">
           <div className="playlist-header">


### PR DESCRIPTION
This pull request introduces a new "Skip" button to the PlaylistBuilder component, allowing users to skip the current tracks and fetch new ones. The changes include the addition of styles for the button, the implementation of the skip functionality, and updates to the component's render method to include the new button.

### Skip Functionality:
* [`src/components/Playlist/PlaylistBuilder.tsx`](diffhunk://#diff-11e2a65617aa13469251d81a44fbcd6ee2912d3fd6d57ea00a3bfd5d6ae05a9dR180-R185): Added the `handleSkipTracks` function to handle the skip action by fetching new tracks.

### Styles for the Skip Button:
* [`src/components/Playlist/PlaylistBuilder.css`](diffhunk://#diff-2265f2c0b8d0cdee308e8aab1a80dfe3c41bd7dddb4236f1a072e72c2e6a6297R349-R411): Added styles for the new skip button, including hover, active, disabled states, and a loading animation.

