### PR TITLE
Implement Spotify Playlist Creation and Management API Methods

### DIFF
--- a/src/components/Playlist/PlaylistBuilder.tsx
+++ b/src/components/Playlist/PlaylistBuilder.tsx
@@ -258,7 +258,6 @@ const PlaylistBuilder: React.FC = () => {
                 </div>
               </div>
 
-              {/* Add VS element between tracks */}
               {index === 0 && tracks.length > 1 && (
                 <div className="vs-badge">
                   <div className="vs-text">⚔️</div>


### PR DESCRIPTION
Closes #19 

This pull request adds comprehensive playlist management capabilities to TrackDuel, allowing users to create new Spotify playlists and add tracks to them directly from the app. The implementation follows Spotify Web API best practices and includes robust error handling and batch processing for larger playlists.

**Added Playlist Creation Methods to SpotifyService**
- `createPlaylist`: Creates a new playlist for the current user with customizable name and description
  - Automatically fetches the current user's ID
  - Creates a private playlist by default
  - Returns complete playlist details including Spotify URL and ID
- `addTracksToPlaylist`: Adds tracks to an existing playlist
  - Implements batch processing to handle the Spotify API's 100-track limit per request
  - Processes large track collections in manageable chunks
- `createPlaylistWithTracks`: Convenience method that combines playlist creation and track addition
  - Single operation to create a playlist and populate it with tracks
  - Optimizes the process by extracting track URIs only once