### PR TITLE
Add Spotify Logout Functionality

### DIFF
--- a/src/components/Auth/Login.css
+++ b/src/components/Auth/Login.css
@@ -184,3 +184,26 @@
   transform: scale(1.05);
   box-shadow: 0 6px 16px rgba(29, 185, 84, 0.4);
 }
+
+.spotify-logout-btn {
+  background-color: #ff4d4d;
+  color: white;
+  border: none;
+  border-radius: 50px;
+  padding: 14px 30px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  margin: 0 auto;
+  box-shadow: 0 4px 12px rgba(255, 77, 77, 0.3);
+}
+
+.spotify-logout-btn:hover {
+  background-color: #ff6666;
+  transform: scale(1.05);
+  box-shadow: 0 6px 16px rgba(255, 77, 77, 0.4);
+}

--- a/src/components/Auth/Logout.tsx
+++ b/src/components/Auth/Logout.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import "../Auth/Login.css";
+
+const Logout: React.FC = () => {
+  const handleLogout = () => {
+    // Clear all Spotify related tokens
+    localStorage.removeItem("spotify_access_token");
+    localStorage.removeItem("spotify_token_expiration");
+    localStorage.removeItem("spotify_auth_state");
+
+    // Redirect to login page
+    window.location.href = "/";
+  };
+
+  return (
+    <button className="spotify-logout-btn" onClick={handleLogout}>
+      Logout
+    </button>
+  );
+};
+
+export default Logout;

--- a/src/components/Playlist/PlaylistBuilder.css
+++ b/src/components/Playlist/PlaylistBuilder.css
@@ -1,3 +1,21 @@
+.header-controls {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 100;
+}
+
+.header-controls .spotify-logout-btn {
+  font-size: 0.9rem;
+  padding: 8px 16px;
+  background-color: rgba(255, 77, 77, 0.8);
+  border-radius: 20px;
+}
+
+.header-controls .spotify-logout-btn:hover {
+  background-color: #ff4d4d;
+}
+
 .playlist-builder {
   background-color: #121212;
   color: white;

--- a/src/components/Playlist/PlaylistBuilder.tsx
+++ b/src/components/Playlist/PlaylistBuilder.tsx
@@ -17,6 +17,7 @@ import { store } from "../../store/store";
 import ConfirmationModal from "../ConfirmationModal/ConfirmationModal";
 import CreatePlaylistModal from "../CreatePlaylistModal/CreatePlaylistModal";
 import AppTour from "../AppTour/AppTour";
+import Logout from "../Auth/Logout";
 
 const PlaylistBuilder: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -282,6 +283,9 @@ const PlaylistBuilder: React.FC = () => {
         onComplete={handleTourComplete}
         onSkip={handleTourSkip}
       />
+      <div className="header-controls">
+        <Logout />
+      </div>
       <h1>TrackDuel</h1>
       <VolumeWarning />
       <div className="track-comparison">


### PR DESCRIPTION
Closes #34 

This PR adds a logout button to the application, allowing users to disconnect their Spotify account and clear authentication data. The button is positioned in the top-right corner of the application for easy access.

- Added a new `Logout` component in the Auth folder
- Implemented token clearing functionality that removes all Spotify authentication data
- Added logout button to the PlaylistBuilder component's header
- Styled the button to match our application design
- Set up redirection to the login page after logout